### PR TITLE
Parameterized health checks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,17 @@ resource "aws_alb_target_group" "app-http" {
   vpc_id   = "${var.vpc_id}"
   port     = 80
   protocol = "HTTP"
+
+  health_check {
+    interval = "${var.health_check_conf["interval"]}"
+    path = "${var.health_check_conf["path"]}"
+    port =  "${var.health_check_conf["port"]}"
+    protocol = "HTTP"
+    timeout = "${var.health_check_conf["timeout"]}"
+    healthy_threshold =  "${var.health_check_conf["healthy_threshold"]}"
+    unhealthy_threshold =  "${var.health_check_conf["unhealthy_threshold"]}"
+    matcher =  "${var.health_check_conf["matcher"]}"
+  }
 }
 
 resource "aws_alb_target_group" "app-https" {
@@ -30,6 +41,17 @@ resource "aws_alb_target_group" "app-https" {
   vpc_id   = "${var.vpc_id}"
   port     = 443
   protocol = "HTTPS"
+
+  health_check {
+    interval = "${var.health_check_conf["interval"]}"
+    path = "${var.health_check_conf["path"]}"
+    port =  "${var.health_check_conf["port"]}"
+    protocol = "HTTPS"
+    timeout = "${var.health_check_conf["timeout"]}"
+    healthy_threshold = "${var.health_check_conf["healthy_threshold"]}"
+    unhealthy_threshold = "${var.health_check_conf["unhealthy_threshold"]}"
+    matcher =  "${var.health_check_conf["matcher"]}"
+  } 
 }
 
 # Listeners

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,18 @@ variable "external_domain_name" {
 variable "route53_external_id" {
   description = "DNS external name id"
 }
+
+variable "health_check_conf" {
+  description = "Parameters to configure health checks for the load balancer target group"
+  type = "map"
+
+  default = {
+    interval = "30"
+    path = "/"
+    port = "traffic-port"
+    timeout = "5"
+    healthy_threshold= "3"
+    unhealthy_threshold = "3"
+    matcher = "200"
+  }
+}


### PR DESCRIPTION
This was to allow Aspyr to change the path that the Load Balancer health check looked at; before it was clogging their logs with 500 errors. A possible improvement is to replace those map key lookups with the proper lookup function. 